### PR TITLE
Add a custom metric namespace

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,3 +26,7 @@ module.exports.wrap = function(object) {
 module.exports.flush = function() {
   MetricsSender.flush()
 }
+
+module.exports.namespace = function(namespace) {
+  MetricsSender.namespace = namespace
+}

--- a/src/sender.js
+++ b/src/sender.js
@@ -24,7 +24,7 @@ export default class MetricsSender {
 
     try {
       this._cloudwatch().putMetricData({
-        Namespace: 'Metrics',
+        Namespace: this.namespace,
         MetricData: this.metrics
       }).promise()
     } catch (e) {
@@ -62,4 +62,11 @@ export default class MetricsSender {
     return this.cloudwatch
   }
 
+  static set namespace(namespace) {
+    this._namespace = namespace
+  }
+
+  static get namespace() {
+    return this._namespace || 'Metrics'
+  }
 }


### PR DESCRIPTION
Hi,

I've implemented a way to set a custom namespace for the reported metrics while keeping the default value `Metrics` if not defined.

Ideally this would be the usage pattern I'm aiming for:

```javascript
'use strict';

const Metrics = require('metricslib');
const AWS = require('aws-sdk');
const s3 = new AWS.S3();

Metrics.namespace('testLambaFunction');

exports.handler = (event, context, callback) => {
  Metrics('listBuckets').execute(_ => s3.listBuckets().promise()).then((values) => {
    callback(null, values);
  });
}
```
Throughout the execution of this lambda function every metric would fall into this lambda function namespace which would it easier to see the hotspots per function instead of aggregated in a single namespace.

Tell me your thoughts,

Thanks,