### PR TITLE
Add listener on the process’s uncaughtException event and flush the metrics

### DIFF
--- a/src/sender.js
+++ b/src/sender.js
@@ -35,12 +35,9 @@ export default class MetricsSender {
   }
 
   static _installHooks() {
-    this._prependListener(process, 'beforeExit', this._beforeExit.bind(this))
-  }
-
-  static _beforeExit() {
-    console.log('Flush metrics beforeExit')
-    this.flush()
+    ['beforeExit', 'uncaughtException'].forEach((event) => {
+      this._prependListener(process, event, this.flush.bind(this))
+    })
   }
 
   // Node 4.x doesn't have prependListener, so we do this craziness


### PR DESCRIPTION
Hi,

I noticed that when I was using this on AWS lambda and an uncaught exception occurs I lost all the unsent metrics, with this change I tapped into the `uncaughtException` event on the process and then it can proceed into flushing the remaining metrics to AWS.

Something to consider, if we're throwing from inside a Promise then the `unhandledRejection` event kicks in and after it I've seen the `beforeExit` event trigger also so it flushes all the metrics in that case so these changes only cover the case where an exception is thrown outside Promises.

Tell me your thoughts.

Thanks,