### PR TITLE
Add a way to disable or enable sending the metrics to AWS

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,3 +26,11 @@ module.exports.wrap = function(object) {
 module.exports.flush = function() {
   MetricsSender.flush()
 }
+
+module.exports.enable = function() {
+  MetricsSender.enabled = true
+}
+
+module.exports.disable = function() {
+  MetricsSender.enabled = false
+}

--- a/src/sender.js
+++ b/src/sender.js
@@ -4,6 +4,7 @@ export default class MetricsSender {
 
   static hookInstalled = false
   static metrics = []
+  static enabled = true
 
   static queue(metric) {
     if (!this.hookInstalled) {
@@ -17,7 +18,7 @@ export default class MetricsSender {
   static flush() {
     console.log(`Transmit ${this.metrics.length} metrics`)
 
-    if (!this.metrics.length)
+    if (!this.metrics.length || !this.enabled)
       return
 
     console.log(this.metrics)


### PR DESCRIPTION
Hi,

I needed a way to disable the metrics when for example I'm developing locally or if I'm running some kind of automated tests so I've implemented a way of enabling/disabling sending the metrics to AWS.

Thanks,