### PR TITLE
Add a way to set a custom logger or silence all logging with a null logger

### DIFF
--- a/src/console_logger.js
+++ b/src/console_logger.js
@@ -1,0 +1,6 @@
+// node.js doesn't have the debug method on console so we alias it to the log method instead
+if (!console.debug) {
+  console.debug = console.log
+}
+
+export default console

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import AWS from 'aws-sdk';
 import MetricsBuilder from 'builder'
 import MetricsSender from 'sender'
 import interceptor from 'interceptor'
+import NullLogger from 'null_logger'
 
 module.exports = function(...args) {
   return new MetricsBuilder(...args)
@@ -29,4 +30,8 @@ module.exports.flush = function() {
 
 module.exports.namespace = function(namespace) {
   MetricsSender.namespace = namespace
+}
+
+module.exports.logger = function(logger) {
+  MetricsSender.logger = logger ? logger : NullLogger
 }

--- a/src/null_logger.js
+++ b/src/null_logger.js
@@ -1,0 +1,8 @@
+export default class NullLogger {
+  static error() {}
+  static info() {}
+  static debug() {}
+  static log() {}
+  static warn() {}
+  static trace() {}
+}

--- a/src/sender.js
+++ b/src/sender.js
@@ -1,9 +1,12 @@
 import AWS from 'aws-sdk';
 
+import ConsoleLogger from 'console_logger'
+
 export default class MetricsSender {
 
   static hookInstalled = false
   static metrics = []
+  static logger = ConsoleLogger
 
   static queue(metric) {
     if (!this.hookInstalled) {
@@ -15,12 +18,12 @@ export default class MetricsSender {
   }
 
   static flush() {
-    console.log(`Transmit ${this.metrics.length} metrics`)
+    this.logger.debug(`Transmit ${this.metrics.length} metrics`)
 
     if (!this.metrics.length)
       return
 
-    console.log(this.metrics)
+    this.logger.debug(this.metrics)
 
     try {
       this._cloudwatch().putMetricData({
@@ -28,7 +31,7 @@ export default class MetricsSender {
         MetricData: this.metrics
       }).promise()
     } catch (e) {
-      console.error('Exception while transmitting metrics (ignored)', e)
+      this.logger.error('Exception while transmitting metrics (ignored)', e)
     }
 
     this.metrics = []


### PR DESCRIPTION
Hi,

I needed a way to silence the Metrics logging in tests but also wanted to plugin my custom logger to the metrics library to ensure I'm still getting value from error logging and such.

So I've added a `logger` method that we can use to set our custom logger or set it to `false` in order to use a `NullLogger` that won't log anything.
The default behaviour of logging to the console was also preserved.

Tell me your thoughts,
Cheers,