### PR TITLE
Fix exception handling when failing to put metrics

### DIFF
--- a/src/sender.js
+++ b/src/sender.js
@@ -26,14 +26,12 @@ export default class MetricsSender {
 
     this.logger.debug(this.metrics)
 
-    try {
-      this._cloudwatch().putMetricData({
-        Namespace: this.namespace,
-        MetricData: this.metrics
-      }).promise()
-    } catch (e) {
-      this.logger.error('Exception while transmitting metrics (ignored)', e)
-    }
+    this._cloudwatch().putMetricData({
+      Namespace: this.namespace,
+      MetricData: this.metrics
+    }).promise().catch((error) => {
+      this.logger.error('Exception while transmitting metrics (ignored)', error)
+    })
 
     this.metrics = []
   }


### PR DESCRIPTION
Hi,

I noticed that when I was getting some failures when putting metrics that the `unhandledRejection` event was being called so I fixed it by having a catch on the promise that sends the metrics.

Now instead of being caught in the `unhandledRejection` it logs the exception like in this example:

```javascript
> var Metrics = require('./lib/metricslib.min.js')
undefined
> var AWS = require('aws-sdk');
undefined
> var s3 = Metrics.wrap(new AWS.S3());
undefined
>
> s3.listBuckets((buckets) => {
...   console.log(buckets)
... })
Promise { <pending> }
> null

> Metrics.flush()
Transmit 1 metrics
[ { MetricName: 'listBuckets',
    Unit: 'Milliseconds',
    Timestamp: 1494604612.69,
    Value: 622 } ]
undefined
> Exception while transmitting metrics (ignored) { ConfigError: Missing region in config
    at Request.VALIDATE_REGION (/Users/pedrocarrico/work/metricslib/node_modules/aws-sdk/lib/event_listeners.js:80:45)
    at Request.callListeners (/Users/pedrocarrico/work/metricslib/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
    at callNextListener (/Users/pedrocarrico/work/metricslib/node_modules/aws-sdk/lib/sequential_executor.js:95:12)
    at /Users/pedrocarrico/work/metricslib/node_modules/aws-sdk/lib/event_listeners.js:74:9
    at finish (/Users/pedrocarrico/work/metricslib/node_modules/aws-sdk/lib/config.js:313:7)
    at /Users/pedrocarrico/work/metricslib/node_modules/aws-sdk/lib/config.js:331:9
    at SharedIniFileCredentials.get (/Users/pedrocarrico/work/metricslib/node_modules/aws-sdk/lib/credentials.js:126:7)
    at getAsyncCredentials (/Users/pedrocarrico/work/metricslib/node_modules/aws-sdk/lib/config.js:325:24)
    at Config.getCredentials (/Users/pedrocarrico/work/metricslib/node_modules/aws-sdk/lib/config.js:345:9)
    at Request.VALIDATE_CREDENTIALS (/Users/pedrocarrico/work/metricslib/node_modules/aws-sdk/lib/event_listeners.js:69:26)
  message: 'Missing region in config',
  code: 'ConfigError',
  time: 2017-05-12T15:57:01.752Z }
```

Thanks,